### PR TITLE
[27521] Fallback to default icon when no gravatar default exists

### DIFF
--- a/frontend/module/globals/global-avatar-fallback.ts
+++ b/frontend/module/globals/global-avatar-fallback.ts
@@ -29,30 +29,29 @@
 /**
  * Listen to failed avatar load requests and replace them with the default icon
  */
-export function registerGlobalAvatarFallback($:JQueryStatic) {
-  $(function() {
-    // We can employ useCapture to avoid binding to every image#error event
-    window.addEventListener('error', (evt) => {
-      const target = evt.target as HTMLElement;
+// We can employ useCapture to avoid binding to every image#error event
+window.addEventListener('error', (evt) => {
+  const target = evt.target as HTMLElement;
 
-      // Replace if we hit a gravatar image
-      if (!(target.tagName === 'IMG' && target.classList.contains('avatar--gravatar-image'))) {
-        return;
-      }
+  // Replace if we hit a gravatar image
+  if (!(target.tagName === 'IMG' && target.classList.contains('avatar--gravatar-image'))) {
+    return;
+  }
 
-      // We need to replace all gravatars with the same source since the error event
-      // is fired only once
-      const src = (target as HTMLImageElement).src;
-      $(`img.avatar--gravatar-image[src="${src}"]`).each((i, el) => {
-        const target = $(el);
-        const classes = target.data('avatarFallbackIcon');
+  // We need to replace all gravatars with the same source since the error event
+  // is fired only once
+  const src = (target as HTMLImageElement).src;
+  const targets = document.querySelectorAll(`img.avatar--gravatar-image[src="${src}"]`)
 
-        target.replaceWith(
-          $('<i>')
-            .addClass(classes)
-            .prop('aria-hidden', true)
-        );
-      });
-    }, true);
-  });
-}
+  for (var i = 0, l = targets.length;  i < l; i++) {
+    const target = targets[i] as HTMLElement;
+    const classes = target.dataset.avatarFallbackIcon || 'icon icon-user';
+
+    const replacement = document.createElement('i');
+    replacement.classList.add(...classes.split(/\s+/));
+    replacement.setAttribute('aria-hidden', 'true');
+
+    const parent = target.parentElement;
+    parent && parent.replaceChild(replacement, target);
+  }
+}, true);

--- a/frontend/module/globals/global-avatar-fallback.ts
+++ b/frontend/module/globals/global-avatar-fallback.ts
@@ -1,0 +1,58 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2017 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2017 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+/**
+ * Listen to failed avatar load requests and replace them with the default icon
+ */
+export function registerGlobalAvatarFallback($:JQueryStatic) {
+  $(function() {
+    // We can employ useCapture to avoid binding to every image#error event
+    window.addEventListener('error', (evt) => {
+      const target = evt.target as HTMLElement;
+
+      // Replace if we hit a gravatar image
+      if (!(target.tagName === 'IMG' && target.classList.contains('avatar--gravatar-image'))) {
+        return;
+      }
+
+      // We need to replace all gravatars with the same source since the error event
+      // is fired only once
+      const src = (target as HTMLImageElement).src;
+      $(`img.avatar--gravatar-image[src="${src}"]`).each((i, el) => {
+        const target = $(el);
+        const classes = target.data('avatarFallbackIcon');
+
+        target.replaceWith(
+          $('<i>')
+            .addClass(classes)
+            .prop('aria-hidden', true)
+        );
+      });
+    }, true);
+  });
+}

--- a/frontend/module/main.ts
+++ b/frontend/module/main.ts
@@ -28,6 +28,7 @@ import {APP_INITIALIZER, Injector, NgModule} from '@angular/core';
 import {AvatarUploadFormComponent} from "./avatar-upload-form/avatar-upload-form.component";
 import {HookService} from "../../hook-service";
 import {BrowserModule} from "@angular/platform-browser";
+import {registerGlobalAvatarFallback} from "./globals/global-avatar-fallback";
 
 
 export function initializeAvatarsPlugin(injector:Injector) {
@@ -38,6 +39,8 @@ export function initializeAvatarsPlugin(injector:Injector) {
         { selector: 'avatar-upload-form', cls: AvatarUploadFormComponent }
       ];
     });
+
+    registerGlobalAvatarFallback(jQuery);
   }
 }
 

--- a/frontend/module/main.ts
+++ b/frontend/module/main.ts
@@ -28,8 +28,7 @@ import {APP_INITIALIZER, Injector, NgModule} from '@angular/core';
 import {AvatarUploadFormComponent} from "./avatar-upload-form/avatar-upload-form.component";
 import {HookService} from "../../hook-service";
 import {BrowserModule} from "@angular/platform-browser";
-import {registerGlobalAvatarFallback} from "./globals/global-avatar-fallback";
-
+import './globals/global-avatar-fallback'
 
 export function initializeAvatarsPlugin(injector:Injector) {
   return () => {
@@ -40,7 +39,6 @@ export function initializeAvatarsPlugin(injector:Injector) {
       ];
     });
 
-    registerGlobalAvatarFallback(jQuery);
   }
 }
 

--- a/lib/open_project/avatars/avatar_manager.rb
+++ b/lib/open_project/avatars/avatar_manager.rb
@@ -17,7 +17,7 @@ module OpenProject
 
         def default_gravatar_options
           [
-            [I18n.t(:label_none), ''],
+            [I18n.t(:label_none), '404'],
             ["Mystery Man", 'mm'],
             ["Wavatars", 'wavatar'],
             ["Identicons", 'identicon'],

--- a/lib/open_project/avatars/engine.rb
+++ b/lib/open_project/avatars/engine.rb
@@ -28,7 +28,7 @@ module OpenProject::Avatars
              settings: {
                default: {
                  enable_gravatars: true,
-                 gravatar_default: 'mm',
+                 gravatar_default: '404',
                  enable_local_avatars: true
                },
                partial: 'settings/openproject_avatars'

--- a/lib/open_project/avatars/patches/avatar_helper_patch.rb
+++ b/lib/open_project/avatars/patches/avatar_helper_patch.rb
@@ -75,6 +75,8 @@ AvatarHelper.class_eval do
 
       tag_options = merge_image_options(user, opts)
       tag_options[:alt] = 'Gravatar'
+      tag_options[:class] << ' avatar--gravatar-image'
+      tag_options[:data] = { :'avatar-fallback-icon' => options.fetch(:fallbackIcon, 'icon icon-user') }
 
       gravatar_image_tag(mail, tag_options)
     end

--- a/spec/helpers/avatar_helper_spec.rb
+++ b/spec/helpers/avatar_helper_spec.rb
@@ -39,7 +39,8 @@ describe AvatarHelper, type: :helper, with_settings: { protocol: 'http' } do
   def gravatar_expected_image_tag(digest, options = {})
     tag_options = options.reverse_merge(title: user.name,
                                         alt: 'Gravatar',
-                                        class: 'avatar').delete_if { |key, value| value.nil? || key == :ssl }
+                                        :'data-avatar-fallback-icon' => "icon icon-user",
+                                        class: 'avatar avatar--gravatar-image').delete_if { |key, value| value.nil? || key == :ssl }
 
     image_tag gravatar_expected_url(digest, options), tag_options
   end


### PR DESCRIPTION
This PR uses the `404` gravatar fallback to return an error when the icon
does not exist. Using an error event handler, we can then replace all
avatars on the page with their defined fallbacks.

https://community.openproject.com/projects/openproject/work_packages/27521